### PR TITLE
[FrameworkBundle] Changed hard coded value to Response class constant (302)

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -74,7 +74,7 @@ class Controller extends ContainerAware
      *
      * @return RedirectResponse
      */
-    public function redirect($url, $status = 302)
+    public function redirect($url, $status = Response::HTTP_FOUND)
     {
         return new RedirectResponse($url, $status);
     }


### PR DESCRIPTION
Replaced hard coded parameter value (code = 302) in redirect method by its equivalent value in Response object constants

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Tests pass? | yes |
| License | MIT |
