### PR TITLE
Support for Array parameters in Route requirement

### DIFF
--- a/Routing/Router.php
+++ b/Routing/Router.php
@@ -152,7 +152,7 @@ class Router extends BaseRouter implements WarmableInterface
             if (is_string($resolved) || is_numeric($resolved)) {
                 return (string) $resolved;
             } else if ($acceptArrayParameters && is_array($resolved)) {
-                return (string) implode('|', $resolved);
+                return implode('|', $resolved);
             }
 
             throw new RuntimeException(sprintf(

--- a/Routing/Router.php
+++ b/Routing/Router.php
@@ -92,7 +92,7 @@ class Router extends BaseRouter implements WarmableInterface
             }
 
             foreach ($route->getRequirements() as $name => $value) {
-                $route->setRequirement($name, $this->resolve($value));
+                $route->setRequirement($name, $this->resolve($value, true));
             }
 
             $route->setPath($this->resolve($route->getPath()));
@@ -116,7 +116,8 @@ class Router extends BaseRouter implements WarmableInterface
     /**
      * Recursively replaces placeholders with the service container parameters.
      *
-     * @param mixed $value The source which might contain "%placeholders%"
+     * @param mixed $value                 The source which might contain "%placeholders%"
+     * @param bool  $acceptArrayParameters Used to allow the the parameter array support (mean one of the array)
      *
      * @return mixed The source with the placeholders replaced by the container
      *               parameters. Arrays are resolved recursively.
@@ -124,7 +125,7 @@ class Router extends BaseRouter implements WarmableInterface
      * @throws ParameterNotFoundException When a placeholder does not exist as a container parameter
      * @throws RuntimeException           When a container value is not a string or a numeric value
      */
-    private function resolve($value)
+    private function resolve($value, $acceptArrayParameters = false)
     {
         if (is_array($value)) {
             foreach ($value as $key => $val) {
@@ -150,6 +151,8 @@ class Router extends BaseRouter implements WarmableInterface
 
             if (is_string($resolved) || is_numeric($resolved)) {
                 return (string) $resolved;
+            } else if ($acceptArrayParameters && is_array($resolved)) {
+                return (string) implode('|', $resolved);
             }
 
             throw new RuntimeException(sprintf(


### PR DESCRIPTION
Sometimes it can be usefull to restrict the parameters of a route to one value of a list defined in the application parameters. 

For example, if I take the example provided here:
http://symfony.com/doc/current/book/translation.html#book-translation-locale-url

If I have an ``active_languages: [fr, en]`` parameter defined in my parameters, it would be useful to be able to provide it directly in a route requirements, like this, to avoid to create another parameter as a string ``active_languages_str: "fr|en"``:

```php
/**
 * @Route("/list/{_locale}", name="list", requirements={"_locale" = "%active_languages%"})
```

I think this case can be applied for other common cases. I can create some tests if this PR is accepted.