### PR TITLE
Container should be protected

### DIFF
--- a/Command/ContainerAwareCommand.php
+++ b/Command/ContainerAwareCommand.php
@@ -25,7 +25,7 @@ abstract class ContainerAwareCommand extends Command implements ContainerAwareIn
     /**
      * @var ContainerInterface|null
      */
-    private $container;
+    protected $container;
 
     /**
      * @return ContainerInterface


### PR DESCRIPTION
Any child of ContainerAwareCommand must have access to the $container, so it should be protected, not private.
