### PR TITLE
 Adding the extension XML for required by XmlUtils and not installed by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "ext-xml": "*",
         "symfony/cache": "~3.3",
         "symfony/class-loader": "~3.2",
         "symfony/dependency-injection": "~3.3-beta2",


### PR DESCRIPTION
 Adding the extension XML for required by XmlUtils and not installed by default (PHP7.1) 

![XmlUtils](https://cloud.githubusercontent.com/assets/1810304/25842959/14ad70fa-34a6-11e7-8d95-a68d4253ba2d.png)
This pull request is referenced on ![symfony/skeleton](https://github.com/symfony/skeleton/pull/7)