### PR TITLE
RedirectController - use 307/308 HTTP status codes

### DIFF
--- a/Controller/RedirectController.php
+++ b/Controller/RedirectController.php
@@ -46,29 +46,37 @@ class RedirectController
      * In case the route name is empty, the status code will be 404 when permanent is false
      * and 410 otherwise.
      *
-     * @param Request    $request          The request instance
-     * @param string     $route            The route name to redirect to
-     * @param bool       $permanent        Whether the redirection is permanent
-     * @param bool|array $ignoreAttributes Whether to ignore attributes or an array of attributes to ignore
+     * @param Request    $request           The request instance
+     * @param string     $route             The route name to redirect to
+     * @param bool       $permanent         Whether the redirection is permanent
+     * @param bool|array $ignoreAttributes  Whether to ignore attributes or an array of attributes to ignore
+     * @param bool       $keepRequestMethod Wheter redirect action should keep HTTP request method
      *
      * @throws HttpException In case the route name is empty
      */
-    public function redirectAction(Request $request, string $route, bool $permanent = false, $ignoreAttributes = false): Response
+    public function redirectAction(Request $request, string $route, bool $permanent = false, $ignoreAttributes = false, bool $keepRequestMethod = false): Response
     {
         if ('' == $route) {
-            throw new HttpException($permanent ? 410 : 404);
+            throw new HttpException($permanent ? Response::HTTP_GONE : Response::HTTP_NOT_FOUND);
         }
 
         $attributes = array();
         if (false === $ignoreAttributes || is_array($ignoreAttributes)) {
             $attributes = $request->attributes->get('_route_params');
-            unset($attributes['route'], $attributes['permanent'], $attributes['ignoreAttributes']);
+            unset($attributes['route'], $attributes['permanent'], $attributes['ignoreAttributes'], $attributes['keepRequestMethod']);
             if ($ignoreAttributes) {
                 $attributes = array_diff_key($attributes, array_flip($ignoreAttributes));
             }
         }
 
-        return new RedirectResponse($this->router->generate($route, $attributes, UrlGeneratorInterface::ABSOLUTE_URL), $permanent ? 301 : 302);
+        if ($keepRequestMethod) {
+            $statusCode = $permanent ? Response::HTTP_PERMANENTLY_REDIRECT : Response::HTTP_TEMPORARY_REDIRECT;
+        } else {
+            @trigger_error('Since next major release redirect action will be made with 307/308 HTTP status codes', \E_USER_DEPRECATED);
+            $statusCode = $permanent ? Response::HTTP_MOVED_PERMANENTLY : Response::HTTP_FOUND;
+        }
+
+        return new RedirectResponse($this->router->generate($route, $attributes, UrlGeneratorInterface::ABSOLUTE_URL), $statusCode);
     }
 
     /**
@@ -80,22 +88,28 @@ class RedirectController
      * In case the path is empty, the status code will be 404 when permanent is false
      * and 410 otherwise.
      *
-     * @param Request     $request   The request instance
-     * @param string      $path      The absolute path or URL to redirect to
-     * @param bool        $permanent Whether the redirect is permanent or not
-     * @param string|null $scheme    The URL scheme (null to keep the current one)
-     * @param int|null    $httpPort  The HTTP port (null to keep the current one for the same scheme or the default configured port)
-     * @param int|null    $httpsPort The HTTPS port (null to keep the current one for the same scheme or the default configured port)
+     * @param Request     $request           The request instance
+     * @param string      $path              The absolute path or URL to redirect to
+     * @param bool        $permanent         Whether the redirect is permanent or not
+     * @param string|null $scheme            The URL scheme (null to keep the current one)
+     * @param int|null    $httpPort          The HTTP port (null to keep the current one for the same scheme or the default configured port)
+     * @param int|null    $httpsPort         The HTTPS port (null to keep the current one for the same scheme or the default configured port)
+     * @param bool        $keepRequestMethod Wheter redirect action should keep HTTP request method
      *
      * @throws HttpException In case the path is empty
      */
-    public function urlRedirectAction(Request $request, string $path, bool $permanent = false, string $scheme = null, int $httpPort = null, int $httpsPort = null): Response
+    public function urlRedirectAction(Request $request, string $path, bool $permanent = false, string $scheme = null, int $httpPort = null, int $httpsPort = null, bool $keepRequestMethod = false): Response
     {
         if ('' == $path) {
-            throw new HttpException($permanent ? 410 : 404);
+            throw new HttpException($permanent ? Response::HTTP_GONE : Response::HTTP_NOT_FOUND);
         }
 
-        $statusCode = $permanent ? 301 : 302;
+        if ($keepRequestMethod) {
+            $statusCode = $permanent ? Response::HTTP_PERMANENTLY_REDIRECT : Response::HTTP_TEMPORARY_REDIRECT;
+        } else {
+            @trigger_error('Since next major release redirect action will be made with 307/308 HTTP status codes', \E_USER_DEPRECATED);
+            $statusCode = $permanent ? Response::HTTP_MOVED_PERMANENTLY : Response::HTTP_FOUND;
+        }
 
         // redirect if the path is a full URL
         if (parse_url($path, PHP_URL_SCHEME)) {

--- a/Tests/Controller/RedirectControllerTest.php
+++ b/Tests/Controller/RedirectControllerTest.php
@@ -33,21 +33,21 @@ class RedirectControllerTest extends TestCase
             $controller->redirectAction($request, '', true);
             $this->fail('Expected Symfony\Component\HttpKernel\Exception\HttpException to be thrown');
         } catch (HttpException $e) {
-            $this->assertSame(410, $e->getStatusCode());
+            $this->assertSame(Response::HTTP_GONE, $e->getStatusCode());
         }
 
         try {
             $controller->redirectAction($request, '', false);
             $this->fail('Expected Symfony\Component\HttpKernel\Exception\HttpException to be thrown');
         } catch (HttpException $e) {
-            $this->assertSame(404, $e->getStatusCode());
+            $this->assertSame(Response::HTTP_NOT_FOUND, $e->getStatusCode());
         }
     }
 
     /**
      * @dataProvider provider
      */
-    public function testRoute($permanent, $ignoreAttributes, $expectedCode, $expectedAttributes)
+    public function testRoute($permanent, $keepRequestMethod, $ignoreAttributes, $expectedCode, $expectedAttributes)
     {
         $request = new Request();
 
@@ -62,6 +62,7 @@ class RedirectControllerTest extends TestCase
                 'permanent' => $permanent,
                 'additional-parameter' => 'value',
                 'ignoreAttributes' => $ignoreAttributes,
+                'keepRequestMethod' => $keepRequestMethod
             ),
         );
 
@@ -76,7 +77,7 @@ class RedirectControllerTest extends TestCase
 
         $controller = new RedirectController($router);
 
-        $returnResponse = $controller->redirectAction($request, $route, $permanent, $ignoreAttributes);
+        $returnResponse = $controller->redirectAction($request, $route, $permanent, $ignoreAttributes, $keepRequestMethod);
 
         $this->assertRedirectUrl($returnResponse, $url);
         $this->assertEquals($expectedCode, $returnResponse->getStatusCode());
@@ -84,12 +85,16 @@ class RedirectControllerTest extends TestCase
 
     public function provider()
     {
-        return array(
-            array(true, false, 301, array('additional-parameter' => 'value')),
-            array(false, false, 302, array('additional-parameter' => 'value')),
-            array(false, true, 302, array()),
-            array(false, array('additional-parameter'), 302, array()),
-        );
+        return [
+            [true, false, false, Response::HTTP_MOVED_PERMANENTLY, ['additional-parameter' => 'value']],
+            array(false, false, false, Response::HTTP_FOUND, ['additional-parameter' => 'value']),
+            array(false, false, true, Response::HTTP_FOUND, []),
+            array(false, false, ['additional-parameter'], Response::HTTP_FOUND, []),
+            array(true, true, false, Response::HTTP_PERMANENTLY_REDIRECT, ['additional-parameter' => 'value']),
+            array(false, true, false, Response::HTTP_TEMPORARY_REDIRECT, ['additional-parameter' => 'value']),
+            array(false, true, true, Response::HTTP_TEMPORARY_REDIRECT, []),
+            array(false, true, ['additional-parameter'], Response::HTTP_TEMPORARY_REDIRECT, []),
+        ];
     }
 
     public function testEmptyPath()
@@ -101,14 +106,14 @@ class RedirectControllerTest extends TestCase
             $controller->urlRedirectAction($request, '', true);
             $this->fail('Expected Symfony\Component\HttpKernel\Exception\HttpException to be thrown');
         } catch (HttpException $e) {
-            $this->assertSame(410, $e->getStatusCode());
+            $this->assertSame(Response::HTTP_GONE, $e->getStatusCode());
         }
 
         try {
             $controller->urlRedirectAction($request, '', false);
             $this->fail('Expected Symfony\Component\HttpKernel\Exception\HttpException to be thrown');
         } catch (HttpException $e) {
-            $this->assertSame(404, $e->getStatusCode());
+            $this->assertSame(Response::HTTP_NOT_FOUND, $e->getStatusCode());
         }
     }
 
@@ -119,7 +124,17 @@ class RedirectControllerTest extends TestCase
         $returnResponse = $controller->urlRedirectAction($request, 'http://foo.bar/');
 
         $this->assertRedirectUrl($returnResponse, 'http://foo.bar/');
-        $this->assertEquals(302, $returnResponse->getStatusCode());
+        $this->assertEquals(Response::HTTP_FOUND, $returnResponse->getStatusCode());
+    }
+
+    public function testFullURLWithMethodKeep()
+    {
+        $request = new Request();
+        $controller = new RedirectController();
+        $returnResponse = $controller->urlRedirectAction($request, 'http://foo.bar/', false, null, null, null, true);
+
+        $this->assertRedirectUrl($returnResponse, 'http://foo.bar/');
+        $this->assertEquals(Response::HTTP_TEMPORARY_REDIRECT, $returnResponse->getStatusCode());
     }
 
     public function testUrlRedirectDefaultPorts()

--- a/Tests/Controller/RedirectControllerTest.php
+++ b/Tests/Controller/RedirectControllerTest.php
@@ -87,13 +87,13 @@ class RedirectControllerTest extends TestCase
     {
         return [
             [true, false, false, Response::HTTP_MOVED_PERMANENTLY, ['additional-parameter' => 'value']],
-            array(false, false, false, Response::HTTP_FOUND, ['additional-parameter' => 'value']),
-            array(false, false, true, Response::HTTP_FOUND, []),
-            array(false, false, ['additional-parameter'], Response::HTTP_FOUND, []),
-            array(true, true, false, Response::HTTP_PERMANENTLY_REDIRECT, ['additional-parameter' => 'value']),
-            array(false, true, false, Response::HTTP_TEMPORARY_REDIRECT, ['additional-parameter' => 'value']),
-            array(false, true, true, Response::HTTP_TEMPORARY_REDIRECT, []),
-            array(false, true, ['additional-parameter'], Response::HTTP_TEMPORARY_REDIRECT, []),
+            [false, false, false, Response::HTTP_FOUND, ['additional-parameter' => 'value']],
+            [false, false, true, Response::HTTP_FOUND, []],
+            [false, false, ['additional-parameter'], Response::HTTP_FOUND, []],
+            [true, true, false, Response::HTTP_PERMANENTLY_REDIRECT, ['additional-parameter' => 'value']],
+            [false, true, false, Response::HTTP_TEMPORARY_REDIRECT, ['additional-parameter' => 'value']],
+            [false, true, true, Response::HTTP_TEMPORARY_REDIRECT, []],
+            [false, true, ['additional-parameter'], Response::HTTP_TEMPORARY_REDIRECT, []],
         ];
     }
 


### PR DESCRIPTION
This resolves issue #26171 - allow to redirect action with 307/308 HTTP status codes instead of 301/302 which will keep HTTP request method