### PR TITLE
fix namespace in eval() KernelShutdownOnTearDownTrait.php

### DIFF
--- a/Test/KernelShutdownOnTearDownTrait.php
+++ b/Test/KernelShutdownOnTearDownTrait.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \ReflectionMethod(TestCase::class, 'tearDown'))->hasReturnType()) {
 eval('
+    namespace Symfony\Bundle\FrameworkBundle\Test;
     /**
      * @internal
      */


### PR DESCRIPTION
stolen namespace in eval'd() code (phpunit8)