### PR TITLE
Allow json helper in AbstractController to accept native json data as input

### DIFF
--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -166,9 +166,9 @@ abstract class AbstractController implements ServiceSubscriberInterface
     /**
      * Returns a JsonResponse that uses the serializer component if enabled, or json_encode.
      */
-    protected function json($data, int $status = 200, array $headers = [], array $context = []): JsonResponse
+    protected function json($data, int $status = 200, array $headers = [], array $context = [], bool $json = false): JsonResponse
     {
-        if ($this->container->has('serializer')) {
+        if (false === $json && $this->container->has('serializer')) {
             $json = $this->container->get('serializer')->serialize($data, 'json', array_merge([
                 'json_encode_options' => JsonResponse::DEFAULT_ENCODING_OPTIONS,
             ], $context));
@@ -176,7 +176,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
             return new JsonResponse($json, $status, $headers, true);
         }
 
-        return new JsonResponse($data, $status, $headers);
+        return new JsonResponse($data, $status, $headers, $json);
     }
 
     /**

--- a/Tests/Controller/AbstractControllerTest.php
+++ b/Tests/Controller/AbstractControllerTest.php
@@ -228,6 +228,19 @@ class AbstractControllerTest extends TestCase
         $this->assertEquals('{}', $response->getContent());
     }
 
+    public function testJsonWithAlreadyNativeJsonData()
+    {
+        $controller = $this->createController();
+        $controller->setContainer(new Container());
+
+        $response = $controller->json('{"foo":"bar"}', 200, [], [], true);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertJsonStringEqualsJsonString(
+            '{"foo":"bar"}',
+            $response->getContent()
+        );
+    }
+
     public function testFile()
     {
         $container = new Container();


### PR DESCRIPTION
Hello,

This is my first contribution to Symfony Framework, so i hope i'm doing it in good way !

**Goal:** Replace in any Custom Controller the standard `new Symfony\Component\HttpFoundation\JsonResponse` by the json helper in `Symfony\Bundle\FrameworkBundle\Controller\AbstractController`

**Current:** if data is not already a json native data, the helper did it job.

**Expected::** But when we want to replace the json response object generation in following code
```
use Symfony\Component\HttpFoundation\JsonResponse;
use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

class MyController extends AbstractController
{
    public function testCallGetList()
    {
        try {         
            $client = new \SoapClient(null, $options);
            $result = $client->getList();
            $statusCode = Response::HTTP_OK;
            $json = true;
        } catch (\Exception $e) {
            $result = ['exception' => $e->getMessage()];
            $statusCode = Response::HTTP_BAD_REQUEST;
            $json = false;
        }
        return new JsonResponse($result, $statusCode, [], $json);
//        return $this->json($result, $statusCode);
    }
}
```

**Actual:** `$result` returns a native json data such as for example, `{"obj_1":"some obj_1 result","obj_2":"some obj_2 result"}`

When I use current json helper in SF 4.4.4, i got `"{\u0022obj_1\u0022:\u0022some obj_1 result\u0022,\u0022obj_2\u0022:\u0022some obj_2 result\u0022}"`

While I expected to have only `{"obj_1":"some obj_1 result","obj_2":"some obj_2 result"}`

So, to solve it, here is my PR, code modified and unit test added !

**History:** Since 3.1 (see https://github.com/symfony/framework-bundle/blob/3.1/CHANGELOG.md)
Added Controller::json to simplify creating JSON responses when using the Serializer component

So versions 3.1+ are all impacted !

Laurent

