### PR TITLE
#37245 set default alias to session.handler when handler_id is not provided

### DIFF
--- a/DependencyInjection/FrameworkExtension.php
+++ b/DependencyInjection/FrameworkExtension.php
@@ -880,6 +880,7 @@ class FrameworkExtension extends Extension
             // Set the handler class to be null
             $container->getDefinition('session.storage.native')->replaceArgument(1, null);
             $container->getDefinition('session.storage.php_bridge')->replaceArgument(0, null);
+            $container->setAlias('session.handler', 'session.handler.native_file')->setPrivate(true);
         } else {
             $container->setAlias('session.handler', $config['handler_id'])->setPrivate(true);
         }

--- a/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -440,6 +440,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals('fr', $container->getParameter('kernel.default_locale'));
         $this->assertEquals('session.storage.native', (string) $container->getAlias('session.storage'));
         $this->assertEquals('session.handler.native_file', (string) $container->getAlias('session.handler'));
+        $this->assertEquals('session.handler', (string) $container->getAlias('SessionHandlerInterface'));
 
         $options = $container->getParameter('session.storage.options');
         $this->assertEquals('_SYMFONY', $options['name']);


### PR DESCRIPTION
### Fix https://github.com/symfony/symfony/issues/37245 ###

Without a configured [`handler_id`](https://symfony.com/doc/current/session.html#configuration), the `session.handler` alias is not created, and somes services depend on this alias specialy.

Related to the reported issue above (affected version 4.4.9), the `ServiceHandlerInterface` is an alias of `session.handler`, when execute : 
- `bin/console debug:container session.handler` : The alias is not defined, so the `ContainerDebugCommand` look for a service containing the `session.handler` as part of his name (ContainerDebugCommand::findServiceIdsContaining() is called and returns by default `session.handler.native_file`)
-  `bin/console debug:container SessionHandlerInterface` : The service is defined as an alias of `session.handler`, when calling `ContainerBuilder::getDefinition('session.handler')` the exception occured as the alias is not defined.

# Suggested solution
Create a default `session.handler` when the param `handler_id` is not provided (I choosed `session.handler.native_file` rather than `NullSessionHandler`).

# Affected versions
From [`3.4`](https://github.com/symfony/framework-bundle/blob/3.4/DependencyInjection/FrameworkExtension.php#L879) to [`5.1`](https://github.com/symfony/framework-bundle/blob/5.1/DependencyInjection/FrameworkExtension.php#L955)