### PR TITLE
Fix for: Third argument in addResource can not be null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 vendor/
 composer.lock
 phpunit.xml
+.idea/framework-bundle.iml
+.idea/misc.xml
+.idea/modules.xml

--- a/Translation/Translator.php
+++ b/Translation/Translator.php
@@ -145,6 +145,8 @@ class Translator extends BaseTranslator implements WarmableInterface
         }
         foreach ($this->resources as $key => $params) {
             list($format, $resource, $locale, $domain) = $params;
+            if($locale==null)
+                $locale="";
             parent::addResource($format, $resource, $locale, $domain);
         }
         $this->resources = [];


### PR DESCRIPTION
Deprecation message:

Passing "null" to the third argument of the "Symfony\Component\Translation\Translator::addResource" method has been deprecated since Symfony 4.4 and will throw an error in 5.0.