### PR TITLE
:bug: (kernel) when configuring the container add services with php extension

### DIFF
--- a/Kernel/MicroKernelTrait.php
+++ b/Kernel/MicroKernelTrait.php
@@ -58,7 +58,8 @@ trait MicroKernelTrait
             $container->import($configDir.'/{services}_'.$this->environment.'.yaml');
         } else {
             $container->import($configDir.'/{services}.php');
-        }
+			$container->import($configDir.'/{services}_'.$this->environment.'.php');
+		}
     }
 
     /**


### PR DESCRIPTION
Hello the community

This is my first PR attempt.

So after reading this [documentation](https://symfony.com/doc/current/service_container.html#remove-services) and unsuccessfully trying to load my `service_test.php`, I've noticed that the `configureContainer(..)` function in the `MicroKernelTrait` file was not configured to automatically load this file.

So either we should fix the documentation, either we should fix the configuration.

Since this package is backed by [Alximy](https://alximy.io) I figured it would be cool 😎 to try and fix 🐛 the configuration.

Anyway share me your thoughts about what should be done !

And I wanted to say that php service configuration is 🔥 so shoutout to the one who did this (I think it's you @nicolas-grekas with this [PR](https://github.com/symfony/symfony/pull/23834) right ? 💪🏻)

Also big thanks to @jeremyFreeAgent for debugging this with me and @HeahDude for showing me the php service configuration PR.