### PR TITLE
add :void for consistency with BaseLintCommand

### DIFF
--- a/Command/YamlLintCommand.php
+++ b/Command/YamlLintCommand.php
@@ -46,7 +46,7 @@ class YamlLintCommand extends BaseLintCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 


### PR DESCRIPTION
Fixes #57527, I think.

Alternatively, we can remove the void return type in BaseLintCommand. 

I'm using php 8.3